### PR TITLE
Tested common commands

### DIFF
--- a/src/main/cpp/RobotContainer.cpp
+++ b/src/main/cpp/RobotContainer.cpp
@@ -14,7 +14,7 @@
 #include "commands/IntakeDrive.h"
 
 // Testing temp
-#include "commands/common/ScoreBall.h"
+#include "commands/common/ScoreBall.h""
 
 RobotContainer::RobotContainer() {
 

--- a/src/main/cpp/commands/TankMove.cpp
+++ b/src/main/cpp/commands/TankMove.cpp
@@ -3,10 +3,6 @@
 // Open Source Software; you can modify and/or share it under the terms of
 // the WPILib BSD license file in the root directory of this project.
 
-/*
-test 1: moved about 0.2 speed 212 cm 5 rotations -> 42cm per rotation
-conversion factor around 2.3
-*/
 
 #include "commands/TankMove.h"
 
@@ -32,10 +28,10 @@ void TankMove::Initialize() {
 void TankMove::Execute() {
     distanceCounter = (-m_drivetrain->m_leftLeadEncoder.GetPosition() + m_drivetrain->m_rightLeadEncoder.GetPosition())/2;
     if (m_distance >= 0 && distanceCounter < m_distance){
-        m_drivetrain->Drive(-0.4, 0.4);
+        m_drivetrain->Drive(0.4, 0.4);
     }
     else if(m_distance < 0 && distanceCounter > m_distance){
-        m_drivetrain->Drive(0.4, -0.4);
+        m_drivetrain->Drive(-0.4, -0.4);
     }
 }
 

--- a/src/main/cpp/commands/TankTurn.cpp
+++ b/src/main/cpp/commands/TankTurn.cpp
@@ -23,10 +23,10 @@ void TankTurn::Initialize() {
 void TankTurn::Execute() {
     double angle = m_drivetrain->m_navX.GetAngle();
     if (m_angle >= 0 && angle < m_angle){
-        m_drivetrain->Drive(0.3, 0.3);
+        m_drivetrain->Drive(0.3, -0.3);
     }
     else if(m_angle < 0 && angle > m_angle){
-        m_drivetrain->Drive(-0.3, -0.3);
+        m_drivetrain->Drive(-0.3, 0.3);
     };
 }
 

--- a/src/main/cpp/commands/autonomous/Ball2.cpp
+++ b/src/main/cpp/commands/autonomous/Ball2.cpp
@@ -25,7 +25,7 @@ Ball2::Ball2(
         // Taxi out
         TankMove(drivetrain, -2),
         // Break tape
-        ArmLower(arm),
+        //ArmLower(arm),
         // Turn around to face the ball
         TankTurn(drivetrain, 180),
         // Get the ball

--- a/src/main/cpp/commands/autonomous/Ball3.cpp
+++ b/src/main/cpp/commands/autonomous/Ball3.cpp
@@ -25,7 +25,7 @@ Ball3::Ball3(
         // Taxi out
         TankMove(drivetrain, -0.5),
         // Break tape
-        ArmLower(arm),
+        //ArmLower(arm),
         // Turn to face ball 1
         TankTurn(drivetrain, -133),
         // Move to ball 1

--- a/src/main/cpp/commands/common/ArmLower.cpp
+++ b/src/main/cpp/commands/common/ArmLower.cpp
@@ -8,7 +8,7 @@ ArmLower::ArmLower(Arm& arm): m_arm(&arm){
     SetName("ArmLower");
     AddCommands(
         // Break tape and lower
-        ArmMove(arm, -0.2, 0.2),
+        ArmMove(arm, -0.3, 0.3),
         // Stop, let it drop by gravity
         ArmMove(arm, 0, 0.2)
     );

--- a/src/main/cpp/commands/common/GrabBall.cpp
+++ b/src/main/cpp/commands/common/GrabBall.cpp
@@ -17,7 +17,7 @@ GrabBall::GrabBall(
         // Move forward while intake in
         frc2::ParallelCommandGroup(
             TankMove(drivetrain, 0.5),
-            IntakeMove(intake, 0.6, 0.6))
+            IntakeMove(intake, -0.6, 1))
     );
 
 }

--- a/src/main/cpp/commands/common/ScoreBall.cpp
+++ b/src/main/cpp/commands/common/ScoreBall.cpp
@@ -29,9 +29,9 @@ ScoreBall::ScoreBall(
         // Dump ball while keeping arm up
         frc2::ParallelCommandGroup(
             IntakeMove(intake, 1, 0.2),
-            ArmMove(arm, 0.1, 5)),
+            ArmMove(arm, 0.1, 0.4)),
         // Move back
-        TankMove(drivetrain, -0.3),
+        TankMove(drivetrain, -2.5),
         ArmLower(arm)
     );
 


### PR DESCRIPTION
tankturn and tankmove: fixed problem with inverted motor
armlower: lowers faster to break tape, and for 0.1s longer
scoreball: added taxi distance to the end, reduced arm up time so save time
grabball: flipped the sign so intake goes in instead of out

